### PR TITLE
Fix connected event not getting fired

### DIFF
--- a/OS2LClient.js
+++ b/OS2LClient.js
@@ -66,11 +66,11 @@ class OS2LClient extends EventEmitter {
    */
   connect(callback) {
     return new Promise(async (resolve, reject) => {
-      function cb() {
+      const cb = () => {
         if (callback) callback();
         this.emit("connected");
         resolve();
-      }
+      };
   
       if (this.client) {
         this.emit("warning", new Error("OS2L Client is already connected!"));


### PR DESCRIPTION
I noticed `OS2LClient.on("connected")` wasn't getting triggered because the `this.emit` shown here is scoped incorrectly:
https://github.com/LordVonAdel/os2l/blob/5ea097ad1aaf0538c5b9242040a9d564aec06b19/OS2LClient.js#L71

Because it sits inside a function called cb() `this.` referrers to the functions context. There's an easy fix for this, in ES6 if you use an arrow function they don't have their own context. Instead, they inherit `this` from the enclosing execution context.
