### PR TITLE
Trigger the closed event in the client disconnects from the server or an error is thrown

### DIFF
--- a/OS2LServer.js
+++ b/OS2LServer.js
@@ -72,6 +72,7 @@ class OS2LServer extends EventEmitter {
           if (index >= 0) {
             this.clients.splice(index, 1);
           }
+          this.emit("closed");
         });
 
         client.on("data", data => {
@@ -101,6 +102,7 @@ class OS2LServer extends EventEmitter {
           if (index >= 0) {
             this.clients.splice(index, 1);
           }
+          this.emit("closed");
         });
       
       });


### PR DESCRIPTION
In the current implementation the closed event is only ever triggered from the server if the server is manually disconnected from the client with `server.stop()`. This triggers the closed event if the client disconnects from the server or an error is thrown causing the server to be killed.